### PR TITLE
Improved routing

### DIFF
--- a/router.go
+++ b/router.go
@@ -237,7 +237,7 @@ func newResponse(data interface{}, status int) (Response, error) {
 }
 
 func (w *responseWriter) Write(data []byte) (int, error) {
-	w.body = data
+	w.body = append(w.body, data...)
 
 	return len(data), nil
 }


### PR DESCRIPTION
The original routing implementation only allowed one handler per HTTP method. This PR makes it so you can register multiple handlers per HTTP method & provide filters on query parameters & headers to determine which route a request should take.

For example, a lambda function that retrieves an item from a database may want different ways of doing so, maybe one handler for lookups by id and another by name, this is now achievable like this:

```go
  router.Handler("GET", idHandler).Queries("id")
  router.Handler("GET", nameHandler).Queries("name")
```

This way, you can ensure that a parameter exists before your handler is ran, meaning less boilerplate for ensuring the presence of parameters in a single handler.