### PR TITLE
Route-specific middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The second parmeter is a logrus formatter, which will output the logs as JSON. Y
 
 ## middleware
 
-You can also provide custom middleware functions that can are executed before your handler. You can prevent execution of your handler by using `w.WriteHeader` method. Any modifications to the response writer that occur during execution of middleware functions will create a response and prevent execution of the handler. Middleware methods are executed in the order they are registered.
+You can also provide custom middleware functions that can are executed before your handler. These can be registered globally or per-route. You can prevent execution of your handler by using `w.WriteHeader` method. Any modifications to the response writer that occur during execution of middleware functions will create a response and prevent execution of the handler. Middleware methods are executed in the order they are registered.
 
 ```go
 func middleware(w lux.ResponseWriter, r *lux.Request) {
@@ -130,5 +130,9 @@ func middleware(w lux.ResponseWriter, r *lux.Request) {
 You can register the middleware like this:
 
 ```go
+// Global middleware
 router.Middleware(middleware)
+
+// Route specific middleware
+router.Handler("GET", getHandler).Middleware(middleware)
 ```

--- a/router_test.go
+++ b/router_test.go
@@ -53,7 +53,9 @@ func TestRouter_UsesMiddleware(t *testing.T) {
 
 		// AND that router has registered handlers
 		for method, handler := range tc.Handlers {
-			router.Handler(method, handler).Headers("content-type", "application/json")
+			router.Handler(method, handler).
+				Headers("content-type", "application/json").
+				Middleware(tc.Middleware)
 		}
 
 		// AND the router has registered middleware


### PR DESCRIPTION
* Added `Middleware` function to `Route` to allow for route specific middleware.
* Modified `Router.Middleware` to take multiple handlers rather than just one.
* Updated README for changes.